### PR TITLE
add map init hook

### DIFF
--- a/src/L.Control.MousePosition.js
+++ b/src/L.Control.MousePosition.js
@@ -31,7 +31,17 @@ L.Control.MousePosition = L.Control.extend({
   }
 
 });
+L.Map.mergeOptions({
+    positionControl: false
+});
+
+L.Map.addInitHook(function () {
+    if (this.options.positionControl) {
+        this.positionControl = new L.Control.MousePosition();
+        this.addControl(this.positionControl);
+    }
+});
 
 L.control.mousePosition = function (options) {
-  return new L.Control.MousePosition(options);
+    return new L.Control.MousePosition(options);
 };


### PR DESCRIPTION
If map.option.positionControl is truthy assign map.positionControl to a new Control.MousePosition with the default options and add it to the map.
