### PR TITLE
Added a prefix option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,4 @@ These are the available options:
 
 `latFormatter:` Custom function to format the latitude value. Defaults to undefined
 
+`prefix:` A string to be appended to the coordinates. Defaults to the empty string ‘’.

--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ These are the available options:
 
 `latFormatter:` Custom function to format the latitude value. Defaults to undefined
 
-`prefix:` A string to be appended to the coordinates. Defaults to the empty string ‘’.
+`prefix:` A string to be prepended to the coordinates. Defaults to the empty string ‘’.

--- a/src/L.Control.MousePosition.js
+++ b/src/L.Control.MousePosition.js
@@ -6,7 +6,8 @@ L.Control.MousePosition = L.Control.extend({
     lngFirst: false,
     numDigits: 5,
     lngFormatter: undefined,
-    latFormatter: undefined
+    latFormatter: undefined,
+    prefix: ""
   },
 
   onAdd: function (map) {
@@ -25,7 +26,8 @@ L.Control.MousePosition = L.Control.extend({
     var lng = this.options.lngFormatter ? this.options.lngFormatter(e.latlng.lng) : L.Util.formatNum(e.latlng.lng, this.options.numDigits);
     var lat = this.options.latFormatter ? this.options.lngFormatter(e.latlng.lat) : L.Util.formatNum(e.latlng.lat, this.options.numDigits);
     var value = this.options.lngFirst ? lng + this.options.separator + lat : lat + this.options.separator + lng;
-    this._container.innerHTML = value;
+    var prefixAndValue = this.options.prefix + ' ' + value;
+    this._container.innerHTML = prefixAndValue;
   }
 
 });


### PR DESCRIPTION
Added a prefix option, similar to the Open Layers API mouse control , to give the ability to specify a prefix to the coordinate position (e.g., Coordinates: X,Y). I wanted this for my project, so I thought I would contribute it back. Thanks! :)
