### PR TITLE
Add formatter for whole string, instead of just lat and long

### DIFF
--- a/src/L.Control.MousePosition.js
+++ b/src/L.Control.MousePosition.js
@@ -5,6 +5,7 @@ L.Control.MousePosition = L.Control.extend({
     emptyString: 'Unavailable',
     lngFirst: false,
     numDigits: 5,
+    latLngFormatter: undefined,
     lngFormatter: undefined,
     latFormatter: undefined,
     prefix: ""
@@ -23,9 +24,16 @@ L.Control.MousePosition = L.Control.extend({
   },
 
   _onMouseMove: function (e) {
-    var lng = this.options.lngFormatter ? this.options.lngFormatter(e.latlng.lng) : L.Util.formatNum(e.latlng.lng, this.options.numDigits);
-    var lat = this.options.latFormatter ? this.options.latFormatter(e.latlng.lat) : L.Util.formatNum(e.latlng.lat, this.options.numDigits);
-    var value = this.options.lngFirst ? lng + this.options.separator + lat : lat + this.options.separator + lng;
+    var lng = e.latlng.lng;
+    var lat = e.latlng.lat;
+	var value = "";
+	if (this.options.latLngFormatter != undefined) {
+		value = this.options.latLngFormatter(lat, lng)
+	} else {
+		lng = this.options.lngFormatter ? this.options.lngFormatter(lng) : L.Util.formatNum(lng, this.options.numDigits);
+		lat = this.options.latFormatter ? this.options.latFormatter(lat) : L.Util.formatNum(lat, this.options.numDigits);
+		value = this.options.lngFirst ? lng + this.options.separator + lat : lat + this.options.separator + lng;
+	}
     var prefixAndValue = this.options.prefix + ' ' + value;
     this._container.innerHTML = prefixAndValue;
   }


### PR DESCRIPTION
This pull request adds the ability to specify a formatter that formats the lat/long as a single string, rather than having to specify them individually.

For example, in the UK we commonly use OSGB as the coordinate system and format the strings something like `SK 123 456` where `SK` refers to a particular bounding box, the `123` is the longitude within that box and the `456` is the lattitude. Clearly, the `SK` is as much as part of the longitude as the lattitude, and thus cannot be written separately.
