### PR TITLE
Cycle thru array of formatter functions when clicked

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,22 +14,8 @@ Insert the following line:
 
 These are the available options:
 
-`position:` The standard Leaflet.Control position parameter. Defaults to 'bottomleft'
-
-`separator:` To separate longitude\latitude values. Defaults to ' : '
-
 `emptystring:` Initial text to display. Defaults to 'Unavailable'
 
-`numDigits:` Number of digits. Defaults to 5
+`formatters:` Array of custom functions to format the mouse position value. When the mouse position control is clicked, the formatter will be advanced to the next function in the array.
 
-`lngFirst:` Weather to put the longitude first or not. Defaults to false
-
-`lngFormatter:` Custom function to format the longitude value. Defaults to undefined
-
-`latFormatter:` Custom function to format the latitude value. Defaults to undefined
-
-`lngFormatters:` Array of custom functions to format the longitude value. When the mouse position control is clicked, the lngFormatter will be advanced to the next function in the array.
-
-`latFormatters:` Array of custom functions to format the latitude value. When the mouse position control is clicked, the latFormatter will be advanced to the next function in the array.
-
-`prefix:` A string to be prepended to the coordinates. Defaults to the empty string ‘’.
+`position:` The standard Leaflet.Control position parameter. Defaults to 'bottomleft'

--- a/README.md
+++ b/README.md
@@ -28,4 +28,8 @@ These are the available options:
 
 `latFormatter:` Custom function to format the latitude value. Defaults to undefined
 
+`lngFormatters:` Array of custom functions to format the longitude value. When the mouse position control is clicked, the lngFormatter will be advanced to the next function in the array.
+
+`latFormatters:` Array of custom functions to format the latitude value. When the mouse position control is clicked, the latFormatter will be advanced to the next function in the array.
+
 `prefix:` A string to be prepended to the coordinates. Defaults to the empty string ‘’.

--- a/src/L.Control.MousePosition.css
+++ b/src/L.Control.MousePosition.css
@@ -5,5 +5,5 @@
   margin:0;
   color: #333;
   font: 11px/1.5 "Helvetica Neue", Arial, Helvetica, sans-serif;
+  cursor: pointer;
 }
-

--- a/src/L.Control.MousePosition.js
+++ b/src/L.Control.MousePosition.js
@@ -1,15 +1,10 @@
 L.Control.MousePosition = L.Control.extend({
   options: {
     position: 'bottomleft',
-    separator: ' : ',
     emptyString: 'Unavailable',
-    lngFirst: false,
-    numDigits: 5,
-    lngFormatter: undefined,
-    latFormatter: undefined,
-    lngFormatters: [],
-    latFormatters: [],
-    prefix: ""
+    formatters: [function(lat, lon) {
+      return L.Util.formatNum(lat, 5) + ':' + L.Util.formatNum(lon, 5)
+    }]
   },
 
   onAdd: function (map) {
@@ -18,7 +13,7 @@ L.Control.MousePosition = L.Control.extend({
     map.on('mousemove', this._onMouseMove, this);
     this._container.innerHTML=this.options.emptyString;
 
-    this._formatterIndex = this.options.lngFormatters.length;
+    this._formatterIndex = this.options.formatters.length;
     this._toggleFormatters();
     const self = this;
     L.DomEvent.on(this._container, 'click', function(e) {
@@ -36,26 +31,18 @@ L.Control.MousePosition = L.Control.extend({
   },
 
   _toggleFormatters: function (e) {
-    if(this.options.lngFormatters.length === 0 
-      || this.options.lngFormatters.length !== this.options.latFormatters.length) return;
-
     this._formatterIndex++;
-    if(this._formatterIndex >= this.options.lngFormatters.length) {
+    if(this._formatterIndex >= this.options.formatters.length) {
       this._formatterIndex = 0;
     }
 
-    this.options.lngFormatter = this.options.lngFormatters[this._formatterIndex];
-    this.options.latFormatter = this.options.latFormatters[this._formatterIndex];
+    this._formatter = this.options.formatters[this._formatterIndex];
     
     if(e) this._onMouseMove(e);
   },
 
   _onMouseMove: function (e) {
-    var lng = this.options.lngFormatter ? this.options.lngFormatter(e.latlng.lng) : L.Util.formatNum(e.latlng.lng, this.options.numDigits);
-    var lat = this.options.latFormatter ? this.options.latFormatter(e.latlng.lat) : L.Util.formatNum(e.latlng.lat, this.options.numDigits);
-    var value = this.options.lngFirst ? lng + this.options.separator + lat : lat + this.options.separator + lng;
-    var prefixAndValue = this.options.prefix + ' ' + value;
-    this._container.innerHTML = prefixAndValue;
+    this._container.innerHTML = this._formatter(e.latlng.lat, e.latlng.lng);
   }
 
 });

--- a/src/L.Control.MousePosition.js
+++ b/src/L.Control.MousePosition.js
@@ -7,6 +7,8 @@ L.Control.MousePosition = L.Control.extend({
     numDigits: 5,
     lngFormatter: undefined,
     latFormatter: undefined,
+    lngFormatters: [],
+    latFormatters: [],
     prefix: ""
   },
 
@@ -15,11 +17,37 @@ L.Control.MousePosition = L.Control.extend({
     L.DomEvent.disableClickPropagation(this._container);
     map.on('mousemove', this._onMouseMove, this);
     this._container.innerHTML=this.options.emptyString;
+
+    this._formatterIndex = this.options.lngFormatters.length;
+    this._toggleFormatters();
+    const self = this;
+    L.DomEvent.on(this._container, 'click', function(e) {
+      self._toggleFormatters({
+        latlng: map.mouseEventToLatLng(e)
+      });
+    });
+
     return this._container;
   },
 
   onRemove: function (map) {
-    map.off('mousemove', this._onMouseMove)
+    L.DomEvent.off(this._container, 'click');
+    map.off('mousemove', this._onMouseMove);
+  },
+
+  _toggleFormatters: function (e) {
+    if(this.options.lngFormatters.length === 0 
+      || this.options.lngFormatters.length !== this.options.latFormatters.length) return;
+
+    this._formatterIndex++;
+    if(this._formatterIndex >= this.options.lngFormatters.length) {
+      this._formatterIndex = 0;
+    }
+
+    this.options.lngFormatter = this.options.lngFormatters[this._formatterIndex];
+    this.options.latFormatter = this.options.latFormatters[this._formatterIndex];
+    
+    if(e) this._onMouseMove(e);
   },
 
   _onMouseMove: function (e) {


### PR DESCRIPTION
Enhances mouse position control by allowing users to provide an array of formatters. Then, when the control is clicked, the format function will cycle to the next function provided by the array.

I needed this functionality to provide a convenient why to switch the display between decimal degrees and degrees minutes seconds.
